### PR TITLE
Add Refund route and CheckRefund

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -7,10 +7,12 @@ import AccountInfo from './AccountInfo';
 import AppContainer from './AppContainer';
 import Certifier from './Certifier';
 import Check from './Check';
+import CheckRefund from './CheckRefund';
 import CountrySelector from './CountrySelector';
 import Details from './Details';
 import Fee from './Fee';
 import Messages from './Messages';
+import Refund from './Refund';
 import Terms from './Terms';
 
 import appStore, { STEPS } from '../stores/app.store';
@@ -27,6 +29,8 @@ export default class App extends Component {
           <Route path='/details' component={Details} />
           <Route path='/tc' component={Terms} />
           <Route path='/check' component={Check} />
+          <Route path='/refund' component={Refund} />
+          <Route path='/check-refund' component={CheckRefund} />
           <Messages />
         </div>
       </Router>

--- a/frontend/src/components/CheckRefund.js
+++ b/frontend/src/components/CheckRefund.js
@@ -1,0 +1,125 @@
+import React, { Component } from 'react';
+import EthJS from 'ethereumjs-util';
+import { Button, Header, Input } from 'semantic-ui-react';
+
+import backend from '../backend';
+import { isValidAddress } from '../utils';
+import feeStore from '../stores/fee.store';
+
+import AppContainer from './AppContainer';
+import AddressInput from './AddressInput';
+
+const preStyle = {
+  fontSize: '0.75em',
+  maxWidth: '100%',
+  whiteSpace: 'pre-line',
+  backgroundColor: '#eee',
+  border: '1px solid black',
+  lineHeight: '1.5em',
+  padding: '0.5em 1em',
+  wordWrap: 'break-word'
+};
+
+export default class CheckRefund extends Component {
+  state = {
+    address: '',
+    loaded: false
+  };
+
+  render () {
+    const { address } = this.state;
+
+    return (
+      <AppContainer
+        hideStepper
+        style={{ textAlign: 'center', padding: '2.5em 1em 2em', maxWidth: '60em', margin: '0 auto' }}
+        title=''
+      >
+        <div>
+          <div style={{ marginBottom: '1.5em' }}>
+            <AddressInput
+              onChange={this.handleAddressChange}
+              value={address}
+            />
+            <Input
+              fluid
+              label='Message'
+              onChange={this.handleMessageChange}
+            />
+            <br />
+            <Input
+              fluid
+              label='Signature'
+              onChange={this.handleSignatureChange}
+            />
+          </div>
+
+          {this.renderResult()}
+
+          <div>
+            <Button secondary as='a' href='/#/'>
+              Go Back
+            </Button>
+          </div>
+        </div>
+      </AppContainer>
+    );
+  }
+
+  renderResult () {
+    const { error, recoveredAddress, origins } = this.state;
+
+    if (error) {
+      return (
+        <div>
+          <p>An error occurred:</p>
+          <pre style={preStyle}>{error.toString()}</pre>
+        </div>
+      );
+    }
+
+    if (recoveredAddress) {
+      return (
+        <div>
+          <p>Recovered address from signature:</p>
+          <pre style={preStyle}>{recoveredAddress}</pre>
+          <p>Payment origins:</p>
+          <pre style={preStyle}>{JSON.stringify(origins)}</pre>
+        </div>
+      );
+    }
+
+    return null;
+  }
+
+  checkValues = async () => {
+    const { address, message, signature } = this.state;
+
+    if (isValidAddress(address) && message && signature) {
+      try {
+        const { origins } = await backend.getAccountFeeInfo(address);
+        const msgHash = EthJS.hashPersonalMessage(EthJS.toBuffer(message));
+        const { v, r, s } = EthJS.fromRpcSig(signature);
+        const publicKey = EthJS.ecrecover(msgHash, v, r, s);
+
+        const recoveredAddress = '0x' + EthJS.pubToAddress(publicKey).toString('hex');
+
+        this.setState({ error: null, recoveredAddress, origins });
+      } catch (error) {
+        this.setState({ error });
+      }
+    }
+  };
+
+  handleAddressChange = (_, { value }) => {
+    this.setState({ address: value, error: null }, this.checkValues);
+  };
+
+  handleMessageChange = (_, { value }) => {
+    this.setState({ message: value, error: null }, this.checkValues);
+  };
+
+  handleSignatureChange = (_, { value }) => {
+    this.setState({ signature: value, error: null }, this.checkValues);
+  };
+}

--- a/frontend/src/components/Refund.js
+++ b/frontend/src/components/Refund.js
@@ -1,0 +1,220 @@
+import React, { Component } from 'react';
+import EthJS from 'ethereumjs-util';
+import { Button, Header } from 'semantic-ui-react';
+
+import backend from '../backend';
+import { isValidAddress } from '../utils';
+import feeStore from '../stores/fee.store';
+
+import AppContainer from './AppContainer';
+import AddressInput from './AddressInput';
+
+const preStyle = {
+  fontSize: '0.75em',
+  maxWidth: '100%',
+  whiteSpace: 'pre-line',
+  backgroundColor: '#eee',
+  border: '1px solid black',
+  lineHeight: '1.5em',
+  padding: '0.5em 1em',
+  wordWrap: 'break-word'
+};
+
+export default class Refund extends Component {
+  state = {
+    address: '',
+    loaded: false
+  };
+
+  render () {
+    const { address } = this.state;
+
+    return (
+      <AppContainer
+        hideStepper
+        style={{ textAlign: 'center', padding: '2.5em 1em 2em', maxWidth: '60em', margin: '0 auto' }}
+        title=''
+      >
+        <div>
+          <div style={{ marginBottom: '1.5em' }}>
+            <Header as='h4' style={{ textTransform: 'uppercase' }}>
+              Enter the Ethereum address that you whish to be refunded
+            </Header>
+            <AddressInput
+              onChange={this.handleAddressChange}
+              value={address}
+            />
+          </div>
+
+          {this.renderResult()}
+
+          <div>
+            <Button secondary as='a' href='/#/'>
+              Go Back
+            </Button>
+          </div>
+        </div>
+      </AppContainer>
+    );
+  }
+
+  renderResult () {
+    if (!this.state.loaded) {
+      return null;
+    }
+
+    const contentStyle = { fontSize: '1.25em', margin: '1em 0 1em', lineHeight: '1.5em' };
+    const { certified, checkCount } = this.state;
+
+    if (certified) {
+      return (
+        <div style={contentStyle}>
+          This address is certified, congratulations!
+        </div>
+      );
+    }
+
+    if (checkCount > 0) {
+      return (
+        <div style={contentStyle}>
+          <div>
+            {checkCount} check(s) have been intiated for
+            this address.
+          </div>
+          <div>
+            No refunds can be sent, sorry.
+          </div>
+        </div>
+      );
+    }
+
+    const { paid, origins } = this.state;
+
+    if (!paid) {
+      return (
+        <div style={contentStyle}>
+          <div>
+            This address has not been paid for.
+          </div>
+          <div>
+            No refunds can be sent, sorry.
+          </div>
+        </div>
+      );
+    }
+
+    const { storedPhrase } = this.state;
+
+    if (!storedPhrase) {
+      return (
+        <div style={contentStyle}>
+          <div>
+            It seems that your cache has been cleared.
+          </div>
+          <div>
+            There is no way to prove to you are at the origin of
+            the fee payment.
+          </div>
+          <div>
+            Please contact us if you think this is a mistake.
+          </div>
+        </div>
+      );
+    }
+
+    const { storedAddress } = this.state;
+
+    if (!origins.includes(storedAddress)) {
+      return (
+        <div style={contentStyle}>
+          <div>
+            We could not match the origin of the payment with
+            the address stored in your browser.
+          </div>
+          <div>
+            Please contact us if you think this is a mistake.
+          </div>
+        </div>
+      );
+    }
+
+    const { message, signature } = this.state;
+
+    return (
+      <div style={contentStyle}>
+        <div>
+          It seems that you are eligible for a refund, congratulations!
+        </div>
+        <div>
+          Please send us information
+          at <a href='mailto:picops@parity.io'>picops@parity.io</a> so
+          we can process the refund.
+        </div>
+        <pre style={preStyle}>{message}</pre>
+        <pre style={preStyle}>{signature}</pre>
+      </div>
+    );
+  }
+
+  async fetchData (who) {
+    const { certified, status, result, reason, error, checkCount, paymentCount } = await backend.checkStatus(who);
+    const data = {
+      certified, status, result, reason, error, checkCount,
+      paymentCount: parseInt(paymentCount)
+    };
+
+    if (certified || checkCount > 0) {
+      return data;
+    }
+
+    const { paid, origins } = await backend.getAccountFeeInfo(who);
+
+    data.paid = paid;
+    data.origins = origins.map((add) => add.toLowerCase());
+
+    if (!paid) {
+      return data;
+    }
+
+    const { storedPhrase } = feeStore;
+
+    data.storedPhrase = storedPhrase;
+
+    if (!storedPhrase) {
+      return data;
+    }
+
+    const { address: storedAddress, secret: storedSecret } = await feeStore.getWallet();
+
+    data.storedAddress = storedAddress.toLowerCase();
+
+    console.warn(storedAddress, origins)
+
+    if (!data.origins.includes(data.storedAddress)) {
+      return data;
+    }
+
+    const message = `I attest I want to get a refund for this address: ${who}`;
+    const privateKey = Buffer.from(storedSecret.slice(2), 'hex');
+
+    const msgHash = EthJS.hashPersonalMessage(EthJS.toBuffer(message));
+    const { v, r, s } = EthJS.ecsign(msgHash, privateKey);
+
+    const signature = EthJS.toRpcSig(v, r, s);
+
+    data.message = message;
+    data.signature = signature;
+
+    return data;
+  }
+
+  handleAddressChange = async (_, { value }) => {
+    this.setState({ address: value, loaded: false });
+
+    if (isValidAddress(value)) {
+      const nextState = await this.fetchData(value);
+
+      this.setState(Object.assign({ loaded: true }, nextState));
+    }
+  };
+}


### PR DESCRIPTION
Adds two routes:

- https://picops.parity.io/#/refund
Users should be sent to this page if they want a refund. The can enter an address, and we check if the address is certified (then it's fine, they shouldn't ask for a refund); if a check has been initiated (we let them know that no refunds can be made); if the address is marked as paid (if not, no refund possible because they never paid); if they still have in their local storage the private of the account which initiated the fee payment. If the private key doesn't exist (they might have cleared their cache), or if it doesn't match the payment origins on the contract, there's not so much we can do (we ask them to contact us for any further questions).
Last case is they didn't initiated any checks and still holds the right private key to prove they are at the origin of the payment. So we sign a message for them and ask them to send the message and the signature to us.

![image](https://user-images.githubusercontent.com/2864519/31253429-280ed806-aa25-11e7-9189-52f0a298e877.png)


- https://picops.parity.io/#/check-refund
This is for us, PICOPS support team. We paste there the address for the refund, the message they signed and the signature. We then display the address recovered from the signature and the payment origins for the address in the first input. If it matches, it means we could most likely refund them, making sure no checks have been created in the meanwhile, etc. (can be done through route 1). We need to make sure we blacklist those address to ever be able to be paid for again.

![image](https://user-images.githubusercontent.com/2864519/31253441-370dfc1a-aa25-11e7-9623-c2b383a7a6fc.png)
