### PR TITLE
Automatic refund

### DIFF
--- a/FeeRegistar.sol
+++ b/FeeRegistar.sol
@@ -188,7 +188,7 @@ contract FeeRegistrar is Delegated {
     require(found);
 
     // Refund the fee to the origin payer
-    origin.transfer(msg.value);
+    who.transfer(msg.value);
   }
 
   /// @notice Change the address of the treasury, the address to which

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1745,6 +1745,11 @@
             "rlp": "2.0.0",
             "secp256k1": "3.3.0"
           }
+        },
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
         }
       }
     },
@@ -3528,11 +3533,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "start": "NODE_CONFIG_DIR=../config node src/main.js | bunyan",
     "sync": "NODE_CONFIG_DIR=../config node src/synchronizer.js | bunyan",
     "start:certifier": "NODE_CONFIG_DIR=../config node src/certifier.js | bunyan",
+    "start:refunder": "NODE_CONFIG_DIR=../config node src/refunder.js | bunyan",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint --ignore-path .gitignore ./src/",
     "lint:js:cached": "eslint --cache --ignore-path .gitignore ./src/",

--- a/backend/src/api/parity.js
+++ b/backend/src/api/parity.js
@@ -72,6 +72,17 @@ class ParityConnector extends EventEmitter {
   }
 
   /**
+   * Get chain id / network version
+   *
+   * @return {Promise<String>} The chain id
+   */
+  netVersion () {
+    return this
+      ._transport
+      .request('net_version');
+  }
+
+  /**
    * Send a signed TX to the Parity node
    *
    * @param  {String} tx `0x` prefixed hex data

--- a/backend/src/certifier.js
+++ b/backend/src/certifier.js
@@ -30,7 +30,7 @@ class AccountCertifier {
 
   async init () {
     try {
-      await store.subscribe(async () => this.verifyOnfidos());
+      await store.subscribe(store.ONFIDO_CHECKS_CHANNEL, async () => this.verifyOnfidos());
       console.warn('\n> Started account certifier!\n');
     } catch (error) {
       console.error(error);
@@ -44,7 +44,7 @@ class AccountCertifier {
 
     this._verifyLock = true;
 
-    await store.scan(async (href) => this.verifyOnfido(href));
+    await store.scan(store.ONFIDO_CHECKS_CHANNEL, async (href) => this.verifyOnfido(href));
 
     this._verifyLock = false;
   }

--- a/backend/src/contracts/account.js
+++ b/backend/src/contracts/account.js
@@ -1,0 +1,22 @@
+// Copyright Parity Technologies (UK) Ltd., 2017.
+// Released under the Apache 2/MIT licenses.
+
+'use strict';
+
+const config = require('config');
+const fs = require('fs');
+const path = require('path');
+const Wallet = require('ethereumjs-wallet');
+
+const { filename, password } = config.get('account');
+const keyFile = fs.readFileSync(path.resolve(__dirname, `../../keys/${filename}`));
+const keyObject = JSON.parse(keyFile.toString());
+
+const wallet = Wallet.fromV3(keyObject, password);
+const account = {
+  address: '0x' + wallet.getAddress().toString('hex'),
+  publicKey: wallet.getPublicKey(),
+  privateKey: wallet.getPrivateKey()
+};
+
+module.exports = account;

--- a/backend/src/contracts/certifier.js
+++ b/backend/src/contracts/certifier.js
@@ -4,25 +4,13 @@
 'use strict';
 
 const config = require('config');
-const fs = require('fs');
-const path = require('path');
 const EthereumTx = require('ethereumjs-tx');
-const Wallet = require('ethereumjs-wallet');
 
+const account = require('./account');
 const { MultiCertifier } = require('../abis');
 const Contract = require('../api/contract');
 
 const gasPrice = config.get('gasPrice');
-const { filename, password } = config.get('account');
-const keyFile = fs.readFileSync(path.resolve(__dirname, `../../keys/${filename}`));
-const keyObject = JSON.parse(keyFile.toString());
-
-const wallet = Wallet.fromV3(keyObject, password);
-const account = {
-  address: '0x' + wallet.getAddress().toString('hex'),
-  publicKey: wallet.getPublicKey(),
-  privateKey: wallet.getPrivateKey()
-};
 
 class Certifier extends Contract {
   /**

--- a/backend/src/contracts/fee.js
+++ b/backend/src/contracts/fee.js
@@ -56,14 +56,18 @@ class Fee extends Contract {
    * Get the payment origins (addresses) and count
    *
    * @param {String} address `0x` prefixed
+   * @param {Object} options Options Object, fallback can be
+   *                         set to `false` if we don't want to
+   *                         fallback to the old fee contract (@see refund)
    *
    * @return {Promise<Object>} contains `paymentCount` and `paymentOrigins`
    */
-  async paymentStatus (address) {
+  async paymentStatus (address, options = { fallback: true }) {
     const [ paymentCount, paymentOrigins ] = await this.methods.payer(address).get();
 
     // Return the new-contract value if any
-    if (paymentCount.gt(0)) {
+    // or if no fallback option set
+    if (paymentCount.gt(0) || !options.fallback) {
       return {
         paymentCount,
         paymentOrigins

--- a/backend/src/main.js
+++ b/backend/src/main.js
@@ -18,7 +18,10 @@ const Fee = require('./contracts/fee');
 const app = new Koa();
 const { port, hostname } = config.get('http');
 
-main().catch((error) => console.error(error));
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 
 async function main () {
   const transport = new CachingTransport(config.get('nodeWs'));

--- a/backend/src/main.js
+++ b/backend/src/main.js
@@ -18,12 +18,12 @@ const Fee = require('./contracts/fee');
 const app = new Koa();
 const { port, hostname } = config.get('http');
 
-main();
+main().catch((error) => console.error(error));
 
 async function main () {
   const transport = new CachingTransport(config.get('nodeWs'));
   const connector = new ParityConnector(transport);
-  const feeRegistrar = new Fee(connector, config.get('feeContract'), config.get('oldFeeContract'));
+  const feeRegistrar = new Fee(connector);
 
   const certifier = new Certifier(connector, config.get('certifierContract'));
 

--- a/backend/src/main.js
+++ b/backend/src/main.js
@@ -49,7 +49,7 @@ async function main () {
     .use(cors())
     .use(etag());
 
-  Routes(app, { connector, certifier, feeRegistrar });
+  await Routes(app, { connector, certifier, feeRegistrar });
 
   app.listen(port, hostname);
 }

--- a/backend/src/refunder.js
+++ b/backend/src/refunder.js
@@ -56,8 +56,8 @@ class Refunder {
     try {
       const txHash = await this._feeRegistrar.refund({ who, origin });
 
-      store.removeRefund({ who, origin });
-      console.warn('TODO: store tx hash', txHash);
+      await store.removeRefund({ who, origin });
+      await store.setRefundData({ who, origin }, { status: 'sent', transaction: txHash });
     } catch (error) {
       console.error(error);
     }

--- a/backend/src/refunder.js
+++ b/backend/src/refunder.js
@@ -1,0 +1,67 @@
+// Copyright Parity Technologies (UK) Ltd., 2017.
+// Released under the Apache 2/MIT licenses.
+
+'use strict';
+
+const config = require('config');
+
+const { RpcTransport } = require('./api/transport');
+const Certifier = require('./contracts/certifier');
+const FeeRegistrar = require('./contracts/fee');
+const store = require('./store');
+const ParityConnector = require('./api/parity');
+
+class Refunder {
+  static run (wsUrl) {
+    return new Refunder(wsUrl);
+  }
+
+  constructor (wsUrl, contractAddress) {
+    const transport = new RpcTransport(wsUrl);
+
+    this._verifyLock = false;
+    this._connector = new ParityConnector(transport);
+    this._certifier = new Certifier(this._connector, config.get('certifierContract'));
+    this._feeRegistrar = new FeeRegistrar(this._connector, config.get('feeContract'), config.get('oldFeeContract'));
+
+    this.init();
+  }
+
+  async init () {
+    try {
+      await store.subscribe(store.FEE_REFUND_CHANNEL, async () => this.processRefunds());
+      console.warn('\n> Started refunder!\n');
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  async processRefunds () {
+    if (this._verifyLock) {
+      return;
+    }
+
+    this._verifyLock = true;
+
+    await store.scan(store.FEE_REFUND_CHANNEL, async (refund) => this.processRefund(refund));
+
+    this._verifyLock = false;
+  }
+
+  async processRefund (refund) {
+    const { who, origin } = JSON.parse(refund);
+
+    console.warn(`> refunding ${origin} who paid for ${who}...`);
+
+    try {
+      const txHash = await this._feeRegistrar.refund({ who, origin });
+
+      store.removeRefund({ who, origin });
+      console.warn('TODO: store tx hash', txHash);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+}
+
+Refunder.run(config.get('nodeWs'));

--- a/backend/src/refunder.js
+++ b/backend/src/refunder.js
@@ -22,7 +22,7 @@ class Refunder {
     this._verifyLock = false;
     this._connector = new ParityConnector(transport);
     this._certifier = new Certifier(this._connector, config.get('certifierContract'));
-    this._feeRegistrar = new FeeRegistrar(this._connector, config.get('feeContract'), config.get('oldFeeContract'));
+    this._feeRegistrar = new FeeRegistrar(this._connector);
 
     this.init();
   }

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -22,6 +22,10 @@ function get ({ connector, certifier, feeRegistrar }) {
   router.get('/:address/incoming-txs', async (ctx, next) => {
     const { address } = ctx.params;
 
+    if (!address || !isValidAddress(address)) {
+      return errorHandler(ctx, 400, 'Invalid address');
+    }
+
     await rateLimiter(address, ctx.remoteAddress);
 
     const balance = await connector.balance(address);
@@ -45,6 +49,10 @@ function get ({ connector, certifier, feeRegistrar }) {
 
   router.get('/:address/fee', async (ctx, next) => {
     const { address } = ctx.params;
+
+    if (!address || !isValidAddress(address)) {
+      return errorHandler(ctx, 400, 'Invalid address');
+    }
 
     await rateLimiter(address, ctx.remoteAddress);
 
@@ -76,6 +84,10 @@ function get ({ connector, certifier, feeRegistrar }) {
   router.get('/:address/nonce', async (ctx, next) => {
     const { address } = ctx.params;
 
+    if (!address || !isValidAddress(address)) {
+      return errorHandler(ctx, 400, 'Invalid address');
+    }
+
     await rateLimiter(address, ctx.remoteAddress);
 
     const nonce = await connector.nextNonce(address);
@@ -87,11 +99,11 @@ function get ({ connector, certifier, feeRegistrar }) {
     const { address, origin } = ctx.params;
 
     if (!address || !isValidAddress(address)) {
-      return errorHandler(ctx, 400, 'Missing address');
+      return errorHandler(ctx, 400, 'Invalid address');
     }
 
     if (!origin || !isValidAddress(origin)) {
-      return errorHandler(ctx, 400, 'Missing origin');
+      return errorHandler(ctx, 400, 'Invalid origin');
     }
 
     await rateLimiter(address, ctx.remoteAddress);

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -81,6 +81,15 @@ function get ({ connector, certifier, feeRegistrar }) {
     ctx.body = { nonce };
   });
 
+  router.post('/:address/refund', async (ctx, next) => {
+    const { address} = ctx.params;
+
+    await rateLimiter(address, ctx.remoteAddress);
+
+    const { message, signature } = ctx.request.body;
+    const [ , paymentOrigins ] = await feeRegistrar.paymentStatus(address);
+  });
+
   return router;
 }
 

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -102,10 +102,6 @@ function get ({ connector, certifier, feeRegistrar }) {
       return errorHandler(ctx, 400, 'Missing signature');
     }
 
-    if (await store.isRefunding(address)) {
-      return errorHandler(ctx, 400, 'Already refunding this address. Please be patient.');
-    }
-
     const identity = new Identity(address);
     const checkCount = await identity.checks.count();
     const { paymentCount, paymentOrigins } = await feeRegistrar.paymentStatus(address, { fallback: false });
@@ -127,7 +123,13 @@ function get ({ connector, certifier, feeRegistrar }) {
       return errorHandler(ctx, 400, 'Payer not found in payment origins.');
     }
 
-    await store.addRefund(address);
+    const refund = { who: address, origin: signAddress };
+
+    if (await store.isRefunding(refund)) {
+      return errorHandler(ctx, 400, 'Already refunding this address. Please be patient.');
+    }
+
+    await store.addRefund(refund);
     ctx.body = { result: 'pending' };
   });
 

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -143,7 +143,7 @@ function get ({ connector, certifier, feeRegistrar }) {
 
     const identity = new Identity(address);
     const checkCount = await identity.checks.count();
-    const { paymentCount, paymentOrigins: _pOrigins } = await feeRegistrar.paymentStatus(address, { fallback: false });
+    const { paymentCount, paymentOrigins: _pOrigins } = await feeRegistrar.paymentStatus(address, { version: 1 });
     const paymentOrigins = _pOrigins.map((a) => a.toLowerCase());
 
     if (paymentCount === 0) {

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -3,12 +3,14 @@
 
 'use strict';
 
-const Router = require('koa-router');
 const config = require('config');
+const EthJS = require('ethereumjs-util');
+const Router = require('koa-router');
 
+const store = require('../store');
 const Identity = require('../identity');
-const { rateLimiter } = require('./utils');
-const { hex2big, big2hex } = require('../utils');
+const { error: errorHandler, rateLimiter } = require('./utils');
+const { buf2add, hex2big, big2hex, isValidAddress } = require('../utils');
 
 const onfidoMaxChecks = config.get('onfido.maxChecks');
 
@@ -82,12 +84,51 @@ function get ({ connector, certifier, feeRegistrar }) {
   });
 
   router.post('/:address/refund', async (ctx, next) => {
-    const { address} = ctx.params;
+    const { address } = ctx.params;
+
+    if (!address || !isValidAddress(address)) {
+      return errorHandler(ctx, 400, 'Missing address');
+    }
 
     await rateLimiter(address, ctx.remoteAddress);
 
     const { message, signature } = ctx.request.body;
-    const [ , paymentOrigins ] = await feeRegistrar.paymentStatus(address);
+
+    if (!message) {
+      return errorHandler(ctx, 400, 'Missing message');
+    }
+
+    if (!signature) {
+      return errorHandler(ctx, 400, 'Missing signature');
+    }
+
+    if (await store.isRefunding(address)) {
+      return errorHandler(ctx, 400, 'Already refunding this address. Please be patient.');
+    }
+
+    const identity = new Identity(address);
+    const checkCount = await identity.checks.count();
+    const { paymentCount, paymentOrigins } = await feeRegistrar.paymentStatus(address, { fallback: false });
+
+    if (paymentCount === 0) {
+      return errorHandler(ctx, 400, 'No payment have been recorded for this address');
+    }
+
+    if (checkCount > (paymentCount - 1) * onfidoMaxChecks) {
+      return errorHandler(ctx, 400, `${checkCount} checks have already been issued, for ${paymentCount} payment.`);
+    }
+
+    const msgHash = EthJS.hashPersonalMessage(EthJS.toBuffer(message));
+    const { v, r, s } = EthJS.fromRpcSig(signature);
+    const signPubKey = EthJS.ecrecover(msgHash, v, r, s);
+    const signAddress = buf2add(EthJS.pubToAddress(signPubKey));
+
+    if (!signAddress || !paymentOrigins.includes(signAddress)) {
+      return errorHandler(ctx, 400, 'Payer not found in payment origins.');
+    }
+
+    await store.addRefund(address);
+    ctx.body = { result: 'pending' };
   });
 
   return router;

--- a/backend/src/routes/chain.js
+++ b/backend/src/routes/chain.js
@@ -51,7 +51,7 @@ function get ({ connector, certifier, feeRegistrar }) {
     // A transaction is valid if the recipient is a fee-payer,
     // or if it's a transaction to the Fee Registrar
     if (to.toLowerCase() !== feeRegistrar.address && !toHasPaid) {
-      return error(ctx, 400, 'Invalid `to` field');
+      // return error(ctx, 400, 'Invalid `to` field');
     }
 
     const value = buf2big(txObj.value);

--- a/backend/src/routes/chain.js
+++ b/backend/src/routes/chain.js
@@ -35,7 +35,7 @@ function get ({ connector, certifier, feeRegistrar }) {
     ctx.body = { certifier: address };
   });
 
-  router.post('/tx', async (ctx, next) => {
+  const txHandler = async (ctx, next) => {
     const { tx } = ctx.request.body;
 
     const txBuf = Buffer.from(tx.substring(2), 'hex');
@@ -68,7 +68,10 @@ function get ({ connector, certifier, feeRegistrar }) {
     const hash = await connector.sendTx(tx);
 
     ctx.body = { hash };
-  });
+  };
+
+  router.post('/fee-tx', txHandler);
+  router.post('/tx', txHandler);
 
   return router;
 }

--- a/backend/src/routes/chain.js
+++ b/backend/src/routes/chain.js
@@ -35,7 +35,7 @@ function get ({ connector, certifier, feeRegistrar }) {
     ctx.body = { certifier: address };
   });
 
-  router.post('/fee-tx', async (ctx, next) => {
+  router.post('/tx', async (ctx, next) => {
     const { tx } = ctx.request.body;
 
     const txBuf = Buffer.from(tx.substring(2), 'hex');

--- a/backend/src/routes/config.js
+++ b/backend/src/routes/config.js
@@ -6,16 +6,18 @@
 const Router = require('koa-router');
 const config = require('config');
 
-function get () {
+async function get ({ connector, certifier, feeRegistrar }) {
   const router = new Router({
     prefix: '/api'
   });
 
-  router.get('/config', async (ctx, next) => {
-    const gasPrice = config.get('gasPrice');
+  const chainId = await connector.netVersion();
+  const gasPrice = config.get('gasPrice');
 
+  router.get('/config', async (ctx, next) => {
     ctx.body = {
-      gasPrice
+      gasPrice,
+      chainId
     };
   });
 

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -8,15 +8,15 @@ const Config = require('./config');
 const Chain = require('./chain');
 const Onfido = require('./onfido');
 
-module.exports = function set (app, { connector, certifier, feeRegistrar }) {
-  [
+module.exports = async function set (app, { connector, certifier, feeRegistrar }) {
+  for (const Route of [
     Accounts,
     Config,
     Chain,
     Onfido
-  ].forEach((Route) => {
-    const instance = Route({ connector, certifier, feeRegistrar });
+  ]) {
+    const instance = await Route({ connector, certifier, feeRegistrar });
 
     app.use(instance.routes(), instance.allowedMethods());
-  });
+  }
 };

--- a/backend/src/routes/onfido.js
+++ b/backend/src/routes/onfido.js
@@ -60,7 +60,7 @@ function get ({ certifier, feeRegistrar }) {
   router.get('/:address', async (ctx, next) => {
     const { address } = ctx.params;
 
-    if (!address || !isValidAddress(address)) {
+    if (!isValidAddress(address)) {
       return errorHandler(ctx, 400, 'Invalid address');
     }
 
@@ -79,7 +79,7 @@ function get ({ certifier, feeRegistrar }) {
   router.post('/:address/applicant', async (ctx, next) => {
     const { address } = ctx.params;
 
-    if (!address || !isValidAddress(address)) {
+    if (!isValidAddress(address)) {
       return errorHandler(ctx, 400, 'Invalid address');
     }
 
@@ -155,7 +155,7 @@ function get ({ certifier, feeRegistrar }) {
     const { address } = ctx.params;
     const { sdkToken } = ctx.request.body;
 
-    if (!address || !isValidAddress(address)) {
+    if (!isValidAddress(address)) {
       return errorHandler(ctx, 400, 'Invalid address');
     }
 

--- a/backend/src/routes/onfido.js
+++ b/backend/src/routes/onfido.js
@@ -12,7 +12,7 @@ const Identity = require('../identity');
 const Onfido = require('../onfido');
 const store = require('../store');
 const { error: errorHandler, rateLimiter } = require('./utils');
-const { buf2add } = require('../utils');
+const { buf2add, isValidAddress } = require('../utils');
 
 const onfidoMaxChecks = config.get('onfido.maxChecks');
 
@@ -60,6 +60,10 @@ function get ({ certifier, feeRegistrar }) {
   router.get('/:address', async (ctx, next) => {
     const { address } = ctx.params;
 
+    if (!address || !isValidAddress(address)) {
+      return errorHandler(ctx, 400, 'Invalid address');
+    }
+
     await rateLimiter(address, ctx.remoteAddress);
 
     const identity = new Identity(address);
@@ -74,6 +78,10 @@ function get ({ certifier, feeRegistrar }) {
 
   router.post('/:address/applicant', async (ctx, next) => {
     const { address } = ctx.params;
+
+    if (!address || !isValidAddress(address)) {
+      return errorHandler(ctx, 400, 'Invalid address');
+    }
 
     await rateLimiter(address, ctx.remoteAddress);
 
@@ -146,6 +154,10 @@ function get ({ certifier, feeRegistrar }) {
   router.post('/:address/check', async (ctx, next) => {
     const { address } = ctx.params;
     const { sdkToken } = ctx.request.body;
+
+    if (!address || !isValidAddress(address)) {
+      return errorHandler(ctx, 400, 'Invalid address');
+    }
 
     await rateLimiter(address, ctx.remoteAddress);
 

--- a/backend/src/scripts/fee-certifier-stats.js
+++ b/backend/src/scripts/fee-certifier-stats.js
@@ -37,7 +37,10 @@ async function main () {
   await fetch(feeRegistrar._oldContract);
 
   async function fetch (feeContractInstance) {
-    const payments = await feeContractInstance.events.Paid().get();
+    const payments = await feeContractInstance.events.Paid().get({
+      fromBlock: '4000000'
+    });
+
     const payers = uniq(payments.map((log) => log.params.who));
     const uncertifiedPayers = [];
 

--- a/backend/src/scripts/fee-certifier-stats.js
+++ b/backend/src/scripts/fee-certifier-stats.js
@@ -30,11 +30,11 @@ main()
 async function main () {
   const transport = new CachingTransport(config.get('nodeWs'));
   const connector = new ParityConnector(transport);
-  const feeRegistrar = new Fee(connector, config.get('feeContract'), config.get('oldFeeContract'));
+  const feeRegistrar = new Fee(connector);
 
   const certifier = new Certifier(connector, config.get('certifierContract'));
 
-  await fetch(feeRegistrar._oldContract);
+  await fetch(feeRegistrar);
 
   async function fetch (feeContractInstance) {
     process.stderr.write('\n> fetching logs...  ');

--- a/backend/src/scripts/fee-certifier-stats.js
+++ b/backend/src/scripts/fee-certifier-stats.js
@@ -46,10 +46,10 @@ async function main () {
 
     for (const payer of payers) {
       const identity = new Identity(payer);
-      const checks = await identity.checks.count();
+      const checks = await identity.checks.getAll();
       const certified = await certifier.isCertified(payer);
       const [ paymentCount ] = await feeContractInstance.methods.payer(payer).get();
-      const mustPay = paymentCount * onfidoMaxChecks <= checks;
+      const mustPay = paymentCount * onfidoMaxChecks <= checks.length;
 
       if (!certified && !mustPay) {
         uncertifiedPayers.push({

--- a/backend/src/scripts/fee-certifier-stats.js
+++ b/backend/src/scripts/fee-certifier-stats.js
@@ -59,5 +59,6 @@ async function main () {
     console.warn(`> received ${payments.length} payements`);
     console.warn(`> by ${payers.length} unique addresses`);
     console.warn(`> of which ${uncertifiedPayers.length} have not been certified yet`);
+    console.warn(JSON.stringify(uncertifiedPayers.slice(0, 10), null, 2));
   }
 }

--- a/backend/src/scripts/fee-certifier-stats.js
+++ b/backend/src/scripts/fee-certifier-stats.js
@@ -52,7 +52,11 @@ async function main () {
       const mustPay = paymentCount * onfidoMaxChecks <= checks;
 
       if (!certified && !mustPay) {
-        uncertifiedPayers.push(payer);
+        uncertifiedPayers.push({
+          who: payer,
+          checks,
+          payments: paymentCount
+        });
       }
     }
 

--- a/backend/src/scripts/fee-certifier-stats.js
+++ b/backend/src/scripts/fee-certifier-stats.js
@@ -48,7 +48,7 @@ async function main () {
       const identity = new Identity(payer);
       const checks = await identity.checks.count();
       const certified = await certifier.isCertified(payer);
-      const [ , paymentCount ] = await feeContractInstance.methods.payer(payer).get();
+      const [ paymentCount ] = await feeContractInstance.methods.payer(payer).get();
       const mustPay = paymentCount * onfidoMaxChecks <= checks;
 
       if (!certified && !mustPay) {

--- a/backend/src/scripts/fee-certifier-stats.js
+++ b/backend/src/scripts/fee-certifier-stats.js
@@ -38,7 +38,7 @@ async function main () {
 
   async function fetch (feeContractInstance) {
     const payments = await feeContractInstance.events.Paid().get({
-      fromBlock: '4000000'
+      fromBlock: '4294787'
     });
 
     const payers = uniq(payments.map((log) => log.params.who));

--- a/backend/src/scripts/fee-certifier-stats.js
+++ b/backend/src/scripts/fee-certifier-stats.js
@@ -63,7 +63,11 @@ async function main () {
         continue;
       }
 
-      const { status } = await identity.getData();
+      const { status, reason } = await identity.getData();
+
+      if (reason === 'blocked-country' || reason === 'used-document') {
+        continue;
+      }
 
       uncertifiedPayers.push({
         who: payer,

--- a/backend/src/store.js
+++ b/backend/src/store.js
@@ -7,6 +7,7 @@ const redis = require('./redis');
 const Identity = require('./identity');
 
 const ONFIDO_CHECKS_CHANNEL = 'picops::onfido-checks-channel';
+const FEE_REFUND_CHANNEL = 'picops::refund-channel';
 
 const REDIS_APPLICANTS_KEY = 'picops::applicants';
 const REDIS_LOCKS_KEY = 'picops::locker';
@@ -191,6 +192,37 @@ class Store {
    */
   static async remove (href) {
     await redis.srem(ONFIDO_CHECKS_CHANNEL, href);
+  }
+
+  /**
+   * Add an address to the Redis Refund Set and publish
+   * a `new` event
+   *
+   * @param {String} who
+   */
+  static async addRefund (who) {
+    await redis.sadd(FEE_REFUND_CHANNEL, who);
+    await redis.publish(FEE_REFUND_CHANNEL, 'new');
+  }
+
+  /**
+   * Check if the given address is in the process
+   * of a refund
+   *
+   * @param {String} who
+   * @returns {Boolean}
+   */
+  static async isRefunding (who) {
+    return redis.sismember(FEE_REFUND_CHANNEL, who);
+  }
+
+  /**
+   * Removes an address from the Redis Refund Set.
+   *
+   * @param {String} who
+   */
+  static async removeRefund (who) {
+    await redis.srem(FEE_REFUND_CHANNEL, who);
   }
 }
 

--- a/backend/src/utils.js
+++ b/backend/src/utils.js
@@ -49,7 +49,7 @@ function buf2add (value) {
 }
 
 function buf2hex (buf) {
-  return `0x${buf.toString('hex')}`;
+  return `0x${buf.toString('hex') || 0}`;
 }
 
 function hex2big (hex) {

--- a/config/default.js
+++ b/config/default.js
@@ -5,8 +5,13 @@ module.exports = {
   },
   nodeWs: 'ws://127.0.0.1:8546/',
   certifierContract: '0x06C4AF12D9E3501C173b5D1B9dd9cF6DCC095b98',
-  oldFeeContract: '0xD5d12e7c067Aecb420C94b47d9CaA27912613378',
-  feeContract: '0x994580775E1B594c5A0275a073DF1Fd431165759',
+  feeContract: '0xad240Af85b212d3fF843Db11Ec2e612E8844FbcF',
+  // Fallback for older fee contracts,
+  // version being the ABI version (currently 2)
+  fallbackFeeContracts: [
+    { address: '0x994580775E1B594c5A0275a073DF1Fd431165759', version: 1 },
+    { address: '0xD5d12e7c067Aecb420C94b47d9CaA27912613378', version: 0 }
+  ],
   onfido: {
     token: '',
     webhookToken: '',

--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -12,9 +12,10 @@ class Backend {
   }
 
   async config () {
-    const { gasPrice } = await get(this.url('/config'));
+    const { chainId, gasPrice } = await get(this.url('/config'));
 
     return {
+      chainId: parseInt(chainId),
       gasPrice: new BigNumber(gasPrice)
     };
   }

--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -30,9 +30,15 @@ class Backend {
   }
 
   async getRefund ({ address, message, signature }) {
-    const { result } = await post(this.url(`/accounts/${address}/refund`), { message, signature });
+    const { status } = await post(this.url(`/accounts/${address}/refund`), { message, signature });
 
-    return result;
+    return status;
+  }
+
+  async getRefundStatus ({ who, origin }) {
+    const { status, transaction } = await get(this.url(`/accounts/${who}/refund/${origin}`));
+
+    return { status, transaction };
   }
 
   async getAccountFeeInfo (address) {

--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -29,6 +29,12 @@ class Backend {
     return { incomingTxs };
   }
 
+  async getRefund ({ address, message, signature }) {
+    const { result } = await post(this.url(`/accounts/${address}/refund`), { message, signature });
+
+    return result;
+  }
+
   async getAccountFeeInfo (address) {
     const { balance, paid, origins } = await get(this.url(`/accounts/${address}/fee`));
 

--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -90,8 +90,8 @@ class Backend {
     return nonce;
   }
 
-  async sendFeeTx (tx) {
-    const { hash } = await post(this.url('/fee-tx'), { tx });
+  async sendTx (tx) {
+    const { hash } = await post(this.url('/tx'), { tx });
 
     return { hash };
   }

--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -95,12 +95,6 @@ class Backend {
 
     return { hash };
   }
-
-  async sendTx (tx) {
-    const { hash, requiredEth } = await post(this.url('/tx'), { tx });
-
-    return { hash, requiredEth };
-  }
 }
 
 const { protocol, hostname, port } = window.location;

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -14,6 +14,7 @@ import Fee from './Fee';
 import Messages from './Messages';
 import Refund from './Refund';
 import Terms from './Terms';
+import Transfer from './Transfer';
 
 import appStore, { STEPS } from '../stores/app.store';
 import feeStore from '../stores/fee.store';
@@ -30,6 +31,7 @@ export default class App extends Component {
           <Route path='/tc' component={Terms} />
           <Route path='/check' component={Check} />
           <Route path='/refund' component={Refund} />
+          <Route path='/transfer' component={Transfer} />
           <Route path='/check-refund' component={CheckRefund} />
           <Messages />
         </div>

--- a/frontend/src/components/Refund.js
+++ b/frontend/src/components/Refund.js
@@ -134,7 +134,7 @@ export default class Refund extends Component {
       );
     }
 
-    const { address, loading, transaction } = this.state;
+    const { loading, transaction } = this.state;
 
     return (
       <div style={contentStyle}>

--- a/frontend/src/components/Refund.js
+++ b/frontend/src/components/Refund.js
@@ -23,7 +23,8 @@ const preStyle = {
 export default class Refund extends Component {
   state = {
     address: '',
-    loaded: false
+    loaded: false,
+    loading: false
   };
 
   render () {
@@ -138,20 +139,18 @@ export default class Refund extends Component {
       );
     }
 
-    const { message, signature } = this.state;
+    const { loading } = this.state;
 
     return (
       <div style={contentStyle}>
         <div>
           It seems that you are eligible for a refund, congratulations!
         </div>
-        <div>
-          Please send us information
-          at <a href='mailto:picops@parity.io'>picops@parity.io</a> so
-          we can process the refund.
+        <div style={{ margin: '1.5em 0' }}>
+          <Button primary size='big' onClick={this.handleGetRefund} loading={loading}>
+            Get a refund
+          </Button>
         </div>
-        <pre style={preStyle}>{message}</pre>
-        <pre style={preStyle}>{signature}</pre>
       </div>
     );
   }
@@ -188,8 +187,6 @@ export default class Refund extends Component {
 
     data.storedAddress = storedAddress.toLowerCase();
 
-    console.warn(storedAddress, origins)
-
     if (!data.origins.includes(data.storedAddress)) {
       return data;
     }
@@ -216,5 +213,13 @@ export default class Refund extends Component {
 
       this.setState(Object.assign({ loaded: true }, nextState));
     }
+  };
+
+  handleGetRefund = async () => {
+    const { message, signature, address } = this.state;
+
+    this.setState({ loading: true });
+
+    await backend.getRefund({ message, signature, address });
   };
 }

--- a/frontend/src/components/Refund.js
+++ b/frontend/src/components/Refund.js
@@ -3,7 +3,7 @@ import EthJS from 'ethereumjs-util';
 import { Button, Header } from 'semantic-ui-react';
 
 import backend from '../backend';
-import { isValidAddress } from '../utils';
+import { isValidAddress, fromWei } from '../utils';
 import appStore from '../stores/app.store';
 import feeStore from '../stores/fee.store';
 
@@ -134,12 +134,15 @@ export default class Refund extends Component {
       );
     }
 
-    const { loading, transaction } = this.state;
+    const { address, loading, transaction } = this.state;
 
     return (
       <div style={contentStyle}>
         <div>
           It seems that you are eligible for a refund, congratulations!
+        </div>
+        <div>
+          We can issue a refund of {fromWei(feeStore.fee).toFormat()} ETH to the address above.
         </div>
         <div style={{ margin: '1.5em 0' }}>
           {

--- a/frontend/src/components/Transfer.js
+++ b/frontend/src/components/Transfer.js
@@ -1,0 +1,170 @@
+import BigNumber from 'bignumber.js';
+import EthereumTx from 'ethereumjs-tx';
+import React, { Component } from 'react';
+import { Button, Header, Loader } from 'semantic-ui-react';
+
+import backend from '../backend';
+import config from '../stores/config.store';
+import { fromWei, int2hex, isValidAddress } from '../utils';
+import appStore from '../stores/app.store';
+import feeStore from '../stores/fee.store';
+
+import AppContainer from './AppContainer';
+import AddressInput from './AddressInput';
+import AccountInfo from './AccountInfo';
+
+const GAS_LIMIT = new BigNumber(21000);
+
+export default class Transfer extends Component {
+  state = {
+    address: '',
+    loading: true,
+    sending: false,
+    storedAddress: null,
+    transaction: null
+  };
+
+  componentWillMount () {
+    this.init().catch((error) => appStore.addError(error));
+  }
+
+  async init () {
+    const { storedPhrase } = feeStore;
+
+    if (!storedPhrase) {
+      return this.setState({ loading: false });
+    }
+
+    const { address: storedAddress, secret: storedSecret } = await feeStore.getWallet();
+
+    this.setState({
+      loading: false,
+      storedAddress,
+      storedSecret
+    });
+  }
+
+  render () {
+    return (
+      <AppContainer
+        hideStepper
+        style={{ textAlign: 'center', padding: '2.5em 1em 2em', maxWidth: '60em', margin: '0 auto' }}
+        title=''
+      >
+        <div>
+          <div style={{ marginBottom: '1.5em' }}>
+            <Header as='h4' style={{ textTransform: 'uppercase' }}>
+              Transfer your funds
+            </Header>
+            {this.renderContent()}
+          </div>
+
+          <div>
+            <Button secondary as='a' href='/#/'>
+              Go Back
+            </Button>
+          </div>
+        </div>
+      </AppContainer>
+    );
+  }
+
+  renderContent () {
+    const { address, loading, sending, storedAddress, transaction } = this.state;
+
+    if (loading) {
+      return (
+        <Loader />
+      );
+    }
+
+    if (!storedAddress) {
+      return (
+        <p>
+          It seemed that you cleared your cache.
+          There is nothing we can do...
+        </p>
+      );
+    }
+
+    const valid = isValidAddress(address) && (address.toLowerCase() !== storedAddress.toLowerCase());
+
+    return (
+      <div>
+        <AccountInfo
+          address={storedAddress}
+          showCertified={false}
+        />
+        <Header as='h4'>
+          Enter an Ethereum address to which the funds should be
+          transfered
+        </Header>
+        <AddressInput
+          onChange={this.handleAddressChange}
+          value={address}
+        />
+        <div style={{ margin: '1.5em 0' }}>
+          {
+            transaction
+              ? (
+                <Button primary basic as='a' href={`https://etherscan.io/tx/${transaction}`}>
+                  View transaction on Etherscan
+                </Button>
+              )
+              : (
+                <Button disabled={!valid} primary size='big' onClick={this.handleSend} loading={sending}>
+                  Send
+                </Button>
+              )
+          }
+        </div>
+      </div>
+    );
+  }
+
+  handleAddressChange = async (_, { value }) => {
+    this.setState({ address: value });
+  };
+
+  handleSend = async () => {
+    this.setState({ sending: true });
+
+    try {
+      const { address, storedAddress, storedSecret } = this.state;
+
+      const { balance } = await backend.getAccountFeeInfo(storedAddress);
+      const gasPrice = config.get('gasPrice');
+      const totalGas = GAS_LIMIT.mul(gasPrice);
+
+      if (balance.lt(totalGas)) {
+        throw new Error(`Not enough funds to send a transaction, missing ${fromWei(totalGas.sub(balance))} ETH...`);
+      }
+
+      const privateKey = Buffer.from(storedSecret.slice(2), 'hex');
+      const nonce = await backend.nonce(storedAddress);
+
+      const txParams = {
+        nonce: int2hex(nonce),
+        gasPrice: int2hex(gasPrice),
+        gasLimit: int2hex(GAS_LIMIT),
+        to: address,
+        value: int2hex(balance.sub(totalGas)),
+        chainId: config.get('chainId')
+      };
+
+      const tx = new EthereumTx(txParams);
+
+      tx.sign(privateKey);
+
+      const serializedTx = tx.serialize();
+      const signedTx = '0x' + serializedTx.toString('hex');
+      const { hash } = await backend.sendFeeTx(signedTx);
+
+      console.warn('sent tx', hash);
+      this.setState({ sending: false, transaction: hash });
+    } catch (error) {
+      appStore.addError(error);
+      this.setState({ sending: false });
+    }
+  };
+}

--- a/frontend/src/stores/config.store.js
+++ b/frontend/src/stores/config.store.js
@@ -14,9 +14,11 @@ class Config {
       return;
     }
 
-    const { gasPrice } = await backend.config();
+    const conf = await backend.config();
 
-    this.gasPrice = gasPrice;
+    Object.keys(conf).forEach((key) => {
+      this[key] = conf[key];
+    });
 
     this.loaded = true;
   }

--- a/frontend/src/stores/transaction.js
+++ b/frontend/src/stores/transaction.js
@@ -1,6 +1,7 @@
 import EthereumTx from 'ethereumjs-tx';
 import { privateToAddress } from 'ethereumjs-util';
 
+import backend from '../backend';
 import config from './config.store';
 import { int2hex, isValidAddress } from '../utils';
 
@@ -18,7 +19,7 @@ class Transaction {
   }
 
   async send ({ gasLimit, to, value, data }) {
-    const nonce = await this.nonce(this.sender);
+    const nonce = await backend.nonce(this.sender);
 
     const gasPrice = config.get('gasPrice');
     const chainId = config.get('chainId');
@@ -39,7 +40,7 @@ class Transaction {
     tx.sign(this.privateKey);
 
     const sigserializedTxnedTx = '0x' + tx.serialize().toString('hex');
-    const { hash } = await this.sendFeeTx(sigserializedTxnedTx);
+    const { hash } = await backend.sendTx(sigserializedTxnedTx);
 
     return { hash };
   }

--- a/frontend/src/stores/transaction.js
+++ b/frontend/src/stores/transaction.js
@@ -1,0 +1,48 @@
+import EthereumTx from 'ethereumjs-tx';
+import { privateToAddress } from 'ethereumjs-util';
+
+import config from './config.store';
+import { int2hex, isValidAddress } from '../utils';
+
+class Transaction {
+  constructor (secret) {
+    const privateKey = Buffer.from(secret.slice(-64), 'hex');
+    const sender = '0x' + privateToAddress(privateKey).toString('hex');
+
+    if (!isValidAddress(sender)) {
+      throw new Error(`invalid private key: ${secret}`);
+    }
+
+    this.sender = sender;
+    this.privateKey = privateKey;
+  }
+
+  async send ({ gasLimit, to, value, data }) {
+    const nonce = await this.nonce(this.sender);
+
+    const gasPrice = config.get('gasPrice');
+    const chainId = config.get('chainId');
+
+    const txParams = {
+      data: data || '0x',
+      gasPrice: int2hex(gasPrice),
+      gasLimit: int2hex(gasLimit),
+      value: int2hex(value),
+
+      chainId,
+      nonce,
+      to
+    };
+
+    const tx = new EthereumTx(txParams);
+
+    tx.sign(this.privateKey);
+
+    const sigserializedTxnedTx = '0x' + tx.serialize().toString('hex');
+    const { hash } = await this.sendFeeTx(sigserializedTxnedTx);
+
+    return { hash };
+  }
+}
+
+export default Transaction;

--- a/frontend/src/stores/transaction.js
+++ b/frontend/src/stores/transaction.js
@@ -35,6 +35,7 @@ class Transaction {
       to
     };
 
+    console.warn('sending tx', txParams);
     const tx = new EthereumTx(txParams);
 
     tx.sign(this.privateKey);

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -41,7 +41,7 @@ export async function get (url) {
 }
 
 export function isValidAddress (value) {
-  return value && value.length === 42 && /^0x[0-9a-g]{40}$/i.test(value);
+  return !!value && value.length === 42 && /^0x[0-9a-g]{40}$/i.test(value);
 }
 
 export async function del (url, body) {


### PR DESCRIPTION
Add a route for users to get a refund if they paid and no checks have been created.
This adds 2 routes:

- `/#/refund` to get an automatic refund, if all the criteria match
- `/#/transfer` to transfer what is left in the throw-away account to any valid address

This needs a new contract to be deployed... The old address should be added in the config (modified the keys).

TODO:

- [x] Update contract to send back funds to `who` instead of `origin` or redirect users to transfer route after refund
- [x] Check if transfer funds route works (had some issues on Kovan)